### PR TITLE
Fixed missing localization strings

### DIFF
--- a/PixivUWP/App.xaml
+++ b/PixivUWP/App.xaml
@@ -76,33 +76,33 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.-
                                     </VisualStateGroup>
                                 </VisualStateManager.VisualStateGroups>
                                 <TextBox x:Name="TextBox"
-                Style="{TemplateBinding TextBoxStyle}"
-                PlaceholderText="{TemplateBinding PlaceholderText}"
-                Header="{TemplateBinding Header}"
-                Width="{TemplateBinding Width}"
-                BorderThickness="1"
-                ScrollViewer.BringIntoViewOnFocusChange="False"
-                Canvas.ZIndex="0"
-                Margin="0"
-                DesiredCandidateWindowAlignment="BottomEdge"/>
+                                Style="{TemplateBinding TextBoxStyle}"
+                                PlaceholderText="{TemplateBinding PlaceholderText}"
+                                Header="{TemplateBinding Header}"
+                                Width="{TemplateBinding Width}"
+                                BorderThickness="1"
+                                ScrollViewer.BringIntoViewOnFocusChange="False"
+                                Canvas.ZIndex="0"
+                                Margin="0"
+                                DesiredCandidateWindowAlignment="BottomEdge"/>
                                 <Popup x:Name="SuggestionsPopup">
                                     <Border x:Name="SuggestionsContainer" BorderThickness="0">
                                         <Border.RenderTransform>
                                             <TranslateTransform x:Name="UpwardTransform"/>
                                         </Border.RenderTransform>
                                         <ListView
-            x:Name="SuggestionsList"
-            Background="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}"
-            BorderThickness="0"
-            BorderBrush="{ThemeResource SystemControlForegroundChromeHighBrush}"
-            DisplayMemberPath="{TemplateBinding DisplayMemberPath}"
-            IsItemClickEnabled="True"
-            ItemTemplate="{TemplateBinding ItemTemplate}"
-            ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
-            ItemContainerStyle="{TemplateBinding ItemContainerStyle}"
-            MaxHeight="{ThemeResource AutoSuggestListMaxHeight}"
-            Margin="{ThemeResource AutoSuggestListMargin}"
-            Padding="{ThemeResource AutoSuggestListPadding}">
+                                            x:Name="SuggestionsList"
+                                            Background="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}"
+                                            BorderThickness="0"
+                                            BorderBrush="{ThemeResource SystemControlForegroundChromeHighBrush}"
+                                            DisplayMemberPath="{TemplateBinding DisplayMemberPath}"
+                                            IsItemClickEnabled="True"
+                                            ItemTemplate="{TemplateBinding ItemTemplate}"
+                                            ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
+                                            ItemContainerStyle="{TemplateBinding ItemContainerStyle}"
+                                            MaxHeight="{ThemeResource AutoSuggestListMaxHeight}"
+                                            Margin="{ThemeResource AutoSuggestListMargin}"
+                                            Padding="{ThemeResource AutoSuggestListPadding}">
                                             <ListView.ItemContainerTransitions>
                                                 <TransitionCollection />
                                             </ListView.ItemContainerTransitions>

--- a/PixivUWP/MainPage.xaml
+++ b/PixivUWP/MainPage.xaml
@@ -302,7 +302,19 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.-
                             </StackPanel>
                         </Grid>
                     </Button>
-                    <AutoSuggestBox x:Name="Searchbox" QuerySubmitted="Searchbox_QuerySubmitted" Grid.Row="2" QueryIcon="Find" x:Uid="searchBox" VerticalAlignment="Center" Style="{StaticResource AutoSuggestWithoutBorder}" Visibility="Collapsed" Opacity="0" Margin="5 0"/>
+                    
+                    <AutoSuggestBox 
+                        x:Name="Searchbox" 
+                        QuerySubmitted="Searchbox_QuerySubmitted" 
+                        Grid.Row="2" 
+                        QueryIcon="Find" 
+                        x:Uid="searchBox" 
+                        VerticalAlignment="Center" 
+                        Style="{StaticResource AutoSuggestWithoutBorder}" 
+                        Visibility="Collapsed" 
+                        Opacity="0" 
+                        Margin="5 0"/>
+                    
                     <Button x:Name="SearchBtn" Grid.Row="2" Style="{StaticResource DimButtonStyle}" Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" Height="48" Width="48" Click="SearchBtn_Click">
                         <TextBlock FontSize="16" FontFamily="Segoe MDL2 Assets" Text="" VerticalAlignment="Center" HorizontalAlignment="Center"/>
                     </Button>

--- a/PixivUWP/Pages/DetailPage/BlankPage.xaml
+++ b/PixivUWP/Pages/DetailPage/BlankPage.xaml
@@ -38,14 +38,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.-
                 <StackPanel Orientation="Vertical" Grid.Column="1">
                     <AutoSuggestBox 
                         x:Name="gotoBox" 
-                        x:Uid="gotoBox"
+                        x:Uid="gotoBox" 
                         HorizontalAlignment="Stretch" 
-                        PlaceholderText="Enter author name or PixivID..." 
-                        BorderThickness="0"
-                        QueryIcon="Find"
+                        PlaceholderText="输入Pixiv作品或作者ID..." 
                         Style="{StaticResource AutoSuggestWithoutBorder}" 
-                        IsEnabled="False"
-                        />
+                        QueryIcon="Find" 
+                        IsEnabled="False"/>
                 </StackPanel>
             </Grid>
         </StackPanel>

--- a/PixivUWP/Pages/DetailPage/BlankPage.xaml
+++ b/PixivUWP/Pages/DetailPage/BlankPage.xaml
@@ -36,7 +36,16 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.-
                     <ColumnDefinition Width="1*"/>
                 </Grid.ColumnDefinitions>
                 <StackPanel Orientation="Vertical" Grid.Column="1">
-                    <AutoSuggestBox x:Name="gotoBox" x:Uid="gotoBox" HorizontalAlignment="Stretch" PlaceholderText="输入Pixiv作品或作者ID..." Style="{StaticResource AutoSuggestWithoutBorder}" QueryIcon="Find" IsEnabled="False"/>
+                    <AutoSuggestBox 
+                        x:Name="gotoBox" 
+                        x:Uid="gotoBox"
+                        HorizontalAlignment="Stretch" 
+                        PlaceholderText="Enter author name or PixivID..." 
+                        BorderThickness="0"
+                        QueryIcon="Find"
+                        Style="{StaticResource AutoSuggestWithoutBorder}" 
+                        IsEnabled="False"
+                        />
                 </StackPanel>
             </Grid>
         </StackPanel>

--- a/PixivUWP/Strings/en-US/Resources.resw
+++ b/PixivUWP/Strings/en-US/Resources.resw
@@ -513,4 +513,8 @@
   <data name="flyreaderlink.Text" xml:space="preserve">
     <value>Fly Reader</value>
   </data>
+  <data name="gotoBox.PlaceholderText" xml:space="preserve">
+    <value>Enter author name or PixivID</value>
+    <comment>空页搜索框提示文字</comment>
+  </data>
 </root>


### PR DESCRIPTION
Missing localization strings are caused XAML parser error. Using English interface language cause this problem and because of that people can't login